### PR TITLE
Translation strings for Laravel's default email notifications

### DIFF
--- a/nl.json
+++ b/nl.json
@@ -1,0 +1,14 @@
+{
+  "Hello!": "Hallo!",
+  "Whoops!": "Oeps..",
+  "Regards": "Met vriendelijke groeten",
+  "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Lukt het niet om op de \":actionText\" knop te klikken? Kopieer en plak dan onderstaande link in je webbrowser:",
+  "Reset Password Notification": "Nieuw wachtwoord instellen",
+  "You are receiving this email because we received a password reset request for your account.": "Je ontvangt deze e-mail omdat er is aangevraagd om een nieuw wachtwoord in te stellen voor je account.",
+  "Reset Password": "Nieuw wachtwoord instellen",
+  "This password reset link will expire in :count minutes.": "Deze link om een nieuw wachtwoord in te stellen verloopt over :count minuten.",
+  "If you did not request a password reset, no further action is required.": "Heb je niet aangevraagd om een nieuw wachtwoord in te stellen, dan hoef je niets te doen.",
+  "Verify Email Address": "E-mailadres bevestigen",
+  "Please click the button below to verify your email address.": "Klik op onderstaande knop om je e-mailadres te bevestigen.",
+  "If you did not create an account, no further action is required.": "Als je geen account hebt aangemaakt, dan hoef je niets te doen."
+}


### PR DESCRIPTION
Some addition to this great repo, making it a bit more complete if you're using most of Laravel's defaults.

The translation strings used here should be present as keys in the `lang/nl.json` file, because they are retrieved using `Lang::get()`, hence the addition of this new file in the repo.

### Includes all strings from:

**Default email notification template**
Source: `vendor/laravel/framework/src/Illuminate/Notifications/resources/views/email.blade.php`
See [Notifications - Customizing The Templates](https://laravel.com/docs/10.x/notifications#customizing-the-templates)

**Reset Password notification**
Source: `vendor/laravel/framework/src/Illuminate/Auth/Notifications/ResetPassword.php`
See [Resetting Passwords - Customization](https://laravel.com/docs/10.x/passwords#password-customization)

**Verify Email notification**
Source: `vendor/laravel/framework/src/Illuminate/Auth/Notifications/VerifyEmail.php`
See [Email Verification - Customization](https://laravel.com/docs/10.x/verification#customization)

See also [Laravel Breeze](https://laravel.com/docs/10.x/starter-kits#laravel-breeze)


